### PR TITLE
Fix missing errno import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ import setuptools.command.build_py
 from distutils.spawn import find_executable
 import subprocess
 from subprocess import check_call
+import errno
 
 
 


### PR DESCRIPTION
When protoc is missing, an appropriate error message shall be printed. However, due to a missing import instead a missing import is signaled.