### PR TITLE
Fix startup in case environment is not properly prepared

### DIFF
--- a/detd/service.py
+++ b/detd/service.py
@@ -75,6 +75,13 @@ class Service(socketserver.UnixDatagramServer):
         try:
             self.setup_unix_domain_socket()
 
+            # Create directory for the socket file
+            try:
+               os.makedirs(os.path.dirname(_SERVICE_UNIX_DOMAIN_SOCKET))
+            except FileExistsError:
+               # directory already exists
+               pass
+
             super().__init__(_SERVICE_UNIX_DOMAIN_SOCKET, ServiceRequestHandler)
 
             self.test_mode = test_mode


### PR DESCRIPTION
If the directory for the socket file does not exist, the start fails and the lock is not cleaned up. Both issues are fixed with this pull request.