### PR TITLE
Setup of VLAN interface

### DIFF
--- a/detd/service.py
+++ b/detd/service.py
@@ -248,7 +248,7 @@ class ServiceRequestHandler(socketserver.DatagramRequestHandler):
     def _mock_add_talker(self, request):
 
         with mock.patch.object(QdiscConfigurator,  'setup', return_value=None), \
-             mock.patch.object(CommandIp,   'run', return_value=None), \
+             mock.patch.object(CommandIp,   'set_vlan', return_value=None), \
              mock.patch.object(DeviceConfigurator, 'setup', return_value=None), \
              mock.patch.object(SystemInformation,  'get_pci_id', return_value=('8086:4B30')), \
              mock.patch.object(SystemInformation,  'get_rate', return_value=1000 * 1000 * 1000), \

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ packages = find:
 python_requires = >=3.8, <3.9
 install_requires =
        protobuf ==3.6.1.3
+       pyroute2
 scripts =
 	setup_qos.sh
 	detd/detd

--- a/tests/common.py
+++ b/tests/common.py
@@ -49,7 +49,7 @@ class RunContext(AbstractContextManager):
 
         if mode == TestMode.HOST:
             self.qdisc_conf_mock  = mock.patch.object(CommandTc,  'run', side_effect=qdisc_exc)
-            self.vlan_conf_mock   = mock.patch.object(CommandIp,   'run', side_effect=vlan_exc)
+            self.vlan_conf_mock   = mock.patch.object(CommandIp,   'set_vlan', side_effect=vlan_exc)
             self.device_conf_mock = mock.patch.object(CommandEthtool, 'run', side_effect=device_exc)
             self.device_pci_id_mock = mock.patch.object(SystemInformation, 'get_pci_id', return_value=('8086:4B30'))
             self.device_channels_mock = mock.patch.object(SystemInformation, 'get_channels_information', return_value=(8,8))

--- a/tests/test_commandstring.py
+++ b/tests/test_commandstring.py
@@ -8,8 +8,6 @@ import inspect
 import re
 import unittest
 
-from detd import CommandStringIpLinkSetVlan
-from detd import CommandStringIpLinkUnsetVlan
 from detd import CommandStringEthtoolFeatures
 from detd import CommandStringEthtoolGetChannelsInformation
 from detd import CommandStringEthtoolSetCombinedChannels
@@ -30,42 +28,6 @@ class TestCommandString(unittest.TestCase):
         harmonized_another = re.sub('\s+', ' ', str(another).strip())
 
         self.assertEqual(harmonized_one, harmonized_another)
-
-
-
-
-    def test_iplinksetvlan(self):
-
-        interface_name = "eth0"
-        stream_vid = 3
-        soprio_to_pcp = "0:7 1:6 2:5 3:4 4:3 5:2 6:1 7:0"
-
-        cmd = CommandStringIpLinkSetVlan(interface_name, stream_vid, soprio_to_pcp)
-        expected = """
-            ip link add
-                    link     eth0
-                    name     eth0.3
-                    type     vlan
-                    protocol 802.1Q
-                    id       3
-                    egress   0:7 1:6 2:5 3:4 4:3 5:2 6:1 7:0"""
-
-        self.assert_commandstring_equal(cmd, expected)
-
-
-
-
-    def test_iplinkunsetvlan(self):
-
-        interface_name = "eth0"
-        stream_vid = 3
-
-        cmd = CommandStringIpLinkUnsetVlan(interface_name, stream_vid)
-        expected = "ip link delete eth0.3"
-
-        self.assert_commandstring_equal(cmd, expected)
-
-
 
 
     def test_ethtoolfeatures(self):

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -232,7 +232,7 @@ class TestManager(unittest.TestCase):
 
         config = setup_config(self.mode)
 
-        with RunContext(self.mode, vlan_exc=subprocess.CalledProcessError(1, "ip")):
+        with RunContext(self.mode, vlan_exc=ValueError("Interface could not be found")):
             manager = Manager()
 
             self.assertRaises(RuntimeError, manager.add_talker, config)


### PR DESCRIPTION
Currently, the VLAN interface is set up via the ip CLI and fails if it already exists.
Switch to directly interfacing via netlink and if the interface exists, ensure the configuration is correct, but do not fail.
