### PR TITLE
RFC: Add support for i226

### DIFF
--- a/detd/devices/intel_i226.py
+++ b/detd/devices/intel_i226.py
@@ -8,11 +8,11 @@
 
 """
 
-
-
+import time
 
 from ..logger import get_logger
 
+from .device import Capability
 from .device import Device
 
 
@@ -23,8 +23,13 @@ logger = get_logger(__name__)
 
 class IntelI226(Device):
 
-    # Devices supporting TSN: i226-LM, i226-IT
-    PCI_IDS_VALID = ['8086:125B', '8086:125D']
+    NUM_TX_QUEUES = 4
+    NUM_RX_QUEUES = 4
+
+    CAPABILITIES = [Capability.Qbv]
+
+    # Devices supporting TSN: i226-LM, i226-IT, i226-V
+    PCI_IDS_VALID = ['8086:125B', '8086:125D', '8086:125C']
 
     # Hardware default. Empty Flash Image (or NVM configuration loading failed)
     PCI_IDS_UNPROGRAMMED = ['8086:125F']
@@ -35,4 +40,41 @@ class IntelI226(Device):
 
         logger.info(f"Initializing {__class__.__name__}")
 
-        raise NotImplementedError("Handler class for i226 TSN Ethernet controller not yet implemented")
+        super().__init__(IntelI226.NUM_TX_QUEUES, IntelI226.NUM_RX_QUEUES)
+
+        if pci_id in IntelI226.PCI_IDS_UNPROGRAMMED:
+            raise "The flash image in this i226 device is empty, or the NVM configuration loading failed."
+
+        self.capabilities = [Capability.Qbv]
+
+        self.features['rxvlan'] = 'off'
+        #self.features['hw-tc-offload'] = 'on'
+
+        # self.num_tx_ring_entries and self.num_rx_ring_entries
+        # Provides the number of ring entries for Tx and Rx rings.
+        # Currently, the code just passes the value to ethtool's --set-ring.
+        self.num_tx_ring_entries = 1024
+        self.num_rx_ring_entries = 1024
+
+
+    def get_rate(self, interface):
+
+        # Without a small delay, the program flow will call ethtool twice too
+        # fast, causing it to return "Unknown!" speed
+        time.sleep(1)
+
+        return self.systeminfo.get_rate(interface)
+
+
+    def get_base_time_multiple(self):
+        return -1
+
+
+    def supports_schedule(self, schedule):
+
+        if schedule.opens_gate_multiple_times_per_cycle():
+            return False
+
+        # FIXME: check additional constraints, like maximum cycle time
+
+        return True


### PR DESCRIPTION
Hi Hector,
I switched to hardware using the i226-V and for that just copy/pasted the code for the i225 and it seems to work for me on first glance. I am a little confused why you excluded i226-V (as well as i225-V) since I did not found any indication in the datasheets that these devices do not support TSN. Also, since the i225 and i226 are so close, it might make sense to merge them into a single driver file.

What are your opinions on that topic?

Greetings,
Florian