### PR TITLE
Enable building Debian package via Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,16 @@ tail /var/log/detd.log
 At this point the service is ready to receive requests.
 
 
+#### Docker
+
+To avoid installing all build dependencies locally, you can also use Docker for building the Debian package:
+
+```
+docker build -f tools/Dockerfile . -t detd_builder
+docker run --name detd_build_container detd_builder
+docker cp detd_build_container:/tmp/detd_0.1.dev0-1_all.deb ./
+docker rm detd_build_container
+```
 
 #### pip
 

--- a/detd/service.py
+++ b/detd/service.py
@@ -75,6 +75,13 @@ class Service(socketserver.UnixDatagramServer):
         try:
             self.setup_unix_domain_socket()
 
+            # Create directory for the socket file
+            try:
+               os.makedirs(os.path.dirname(_SERVICE_UNIX_DOMAIN_SOCKET))
+            except FileExistsError:
+               # directory already exists
+               pass
+
             super().__init__(_SERVICE_UNIX_DOMAIN_SOCKET, ServiceRequestHandler)
 
             self.test_mode = test_mode

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,0 +1,22 @@
+FROM debian:bookworm
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update --fix-missing && \
+    apt-get upgrade --assume-yes --no-install-recommends && \
+    apt-get install --assume-yes --no-install-recommends \
+    debmake debhelper-compat dh-python \
+    python3 python3-all python3-setuptools \
+    protobuf-compiler python3-protobuf && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+ADD . /usr/local/src/detd/
+
+WORKDIR /usr/local/src/detd/tools
+
+# Work around bug in debmake
+RUN ln -s /usr/lib/debmake/python3.short /usr/lib/debmakepython3.short
+RUN ln -s /usr/lib/debmake/python3.long /usr/lib/debmakepython3.long
+
+CMD ./package_debian.sh
+

--- a/tools/package_debian.sh
+++ b/tools/package_debian.sh
@@ -9,8 +9,7 @@
 # Generates a rudimentary deb package to facilitate installations on Debian
 # based distributions. The package is then copied to /tmp
 
-
-
+set -e # exit early on errors
 
 function usage () {
    echo "Usage:"

--- a/tools/package_debian.sh
+++ b/tools/package_debian.sh
@@ -79,7 +79,7 @@ function create_deb () {
 
 	echo -e "\tdh_installsystemd" >> debian/rules
 	# Restart detd when the application is upgraded
-	echo -e "\noverride_dh_systemd_start:\n\tdh_systemd_start --restart-after-upgrade" >> debian/rules
+	echo -e "\noverride_dh_installsystemd:\n\tdh_installsystemd --restart-after-upgrade" >> debian/rules
 	# Force xz for compression, to prevent installation issues with Zstandard
 	echo -e "\noverride_dh_builddeb:\n\tdh_builddeb -- -Zxz" >> debian/rules
 

--- a/tools/package_debian.sh
+++ b/tools/package_debian.sh
@@ -49,6 +49,7 @@ function create_deb () {
 	# E.g. detd-0.1.dev0 (PKG: detd, VERSION: 0.1.dev0)
 	PKG=$(awk '/^name/{print $3}' ./setup.cfg)
 	VERSION=$(awk '/^version/{print $3}' ./setup.cfg)
+	REVISION=1
 	ID="${PKG}-${VERSION}"
 
 
@@ -61,7 +62,9 @@ function create_deb () {
 
 	# Generate and customize the debian directory
 	cd ${TMPDIR}/${ID}
-	debmake --binaryspec ':py3' --email ${EMAIL} --fullname ${FULLNAME} --spec
+	debmake --binaryspec ':py3' --email ${EMAIL} --fullname ${FULLNAME} --spec --revision ${REVISION}
+
+	ARCHITECTURE=`grep -Po 'Architecture: \K\S+' debian/control`
 
 	cp ${TMPDIR}/detd.service debian/
 
@@ -82,10 +85,11 @@ function create_deb () {
 
 	# Generate the deb, make it available and perform clean-up
 	fakeroot debian/rules binary
-	dpkg --contents ../*deb
-	dpkg -I ../*deb
-	cp ../*deb /tmp
-	echo "The deb package is now available in /tmp"
+	FILENAME=${PKG}_${VERSION}-${REVISION}_${ARCHITECTURE}.deb
+	dpkg --contents ../${FILENAME}
+	dpkg -I ../${FILENAME}
+	cp ../${FILENAME} /tmp
+	echo "The deb package is now available at /tmp/${FILENAME}"
 
 	rm -rf ${TMPDIR}
 


### PR DESCRIPTION
To enable building for other distributions or without
installing the build dependencies locally, provide a
Dockerfile and the corresponding usage guide.

Also fix a few issues with the current Debian build script.