### PR TITLE
Add DetdMessage wrapper

### DIFF
--- a/detd/ipc.proto
+++ b/detd/ipc.proto
@@ -10,6 +10,7 @@ enum TxSelection{
     STRICT_PRIO = 1;
 }
 
+
 message StreamQosRequest {
 	string interface = 1;
 	uint32 period = 2;
@@ -38,3 +39,10 @@ message StreamQosResponse {
 	uint32  socket_priority = 3;
 }
 
+
+message DetdMessage {
+	oneof msg {
+	    StreamQosRequest stream_qos_request = 1;
+	    StreamQosResponse stream_qos_response = 2;
+	}
+}


### PR DESCRIPTION
Add DetdMessage that wraps the actual messages using protobuf's oneof keyword.

It allows to identify the class of message easily in the proxy and service code.